### PR TITLE
Issue#21

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,13 @@
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
+
+### Gradle ###
+.gradle
+build/
+
+# Ignore Gradle GUI config
+gradle-app.setting
+
+# Avoid ignoring Gradle wrapper jar file (.jar files are usually ignored)
+!gradle-wrapper.jar

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+language: java
+jdk:
+    - openjdk7
+    - oraclejdk7

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,7 @@
 apply plugin: 'java'
 
+sourceCompatibility = 1.6
+
 sourceSets {
     main {
         java {
@@ -20,5 +22,14 @@ sourceSets {
             srcDir 'src/resources'
         }
     }
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    //Unit testing
+    testCompile group: 'junit', name: 'junit', version: '+'    
 }
 

--- a/gradle.build
+++ b/gradle.build
@@ -1,0 +1,24 @@
+apply plugin: 'java'
+
+sourceSets {
+    main {
+        java {
+            srcDir 'src/main'
+        }
+
+        resources {
+            srcDir 'src/resources'
+        }
+    }
+
+    test {
+        java {
+            srcDir 'src/test'
+        }
+
+        resources {
+            srcDir 'src/resources'
+        }
+    }
+}
+

--- a/src/main/Main.java
+++ b/src/main/Main.java
@@ -1,0 +1,6 @@
+
+public class Main {
+    public static void main(String[] args) {
+        System.out.println("Hello, Szoftlab4!");
+    }
+}


### PR DESCRIPTION
Added initial support for Travis and Gradle (the Java build system). We still need to test if JUnit tests build and run correctly on Travis. 

Even though we are most likely targetting Java 6, Travis only supports the Oracle JDK >= 7.0, so we are building against OpenJDK 7 and OracleJDK 7.