### PR TITLE
Quality of life scripting improvements

### DIFF
--- a/build_docs.sh
+++ b/build_docs.sh
@@ -11,11 +11,18 @@ export DOCS_DIR="$TOP_DIR/docs"
 
 source $LIB_DIR/debug_print.sh
 
+normalize="$1"
+
 # We will have to generate the docs multiple times, but on a fail it's easier to debug only
 # one of the LaTeX outputs. Also note that this function doesn't clean up the temporaries,
 # which can be useful in the debugging process
 function generate_docs {
-    pdflatex -halt-on-error "$DOCS_DIR/szoftlab4.tex" | pdflatex_normalize | pdflatex_colorize
+    if [ "$normalize" == "--no-normalize" ]; then
+        pdflatex -halt-on-error "$DOCS_DIR/szoftlab4.tex" | pdflatex_colorize
+    else
+        pdflatex -halt-on-error "$DOCS_DIR/szoftlab4.tex" | pdflatex_normalize | pdflatex_colorize
+    fi
+
     if [ $? -ne 0 ]; then
         debug_error "Generating of the documentation ended. [FAILED]"
         exit -1

--- a/build_docs.sh
+++ b/build_docs.sh
@@ -12,13 +12,12 @@ source $LIB_DIR/debug_print.sh
 # one of the LaTeX outputs. Also note that this function doesn't clean up the temporaries,
 # which can be useful in the debugging process
 function generate_docs {
-    pdflatex -halt-on-error "$DOCS_DIR/szoftlab4.tex" | pdflatex_colorize
+    pdflatex -halt-on-error "$DOCS_DIR/szoftlab4.tex" | pdflatex_normalize
     if [ $? -ne 0 ]; then
         debug_error "Generating of the documentation ended. [FAILED]"
         exit -1
     fi
     
-    echo
     echo
 }
 

--- a/build_docs.sh
+++ b/build_docs.sh
@@ -6,15 +6,20 @@ export SRC_DIR="$TOP_DIR/src"
 export LIB_DIR="$TOP_DIR/lib"
 export DOCS_DIR="$TOP_DIR/docs"
 
+source $LIB_DIR/debug_print.sh
+
 # We will have to generate the docs multiple times, but on a fail it's easier to debug only
 # one of the LaTeX outputs. Also note that this function doesn't clean up the temporaries,
 # which can be useful in the debugging process
 function generate_docs {
-    pdflatex -halt-on-error "$DOCS_DIR/szoftlab4.tex"
+    pdflatex -halt-on-error "$DOCS_DIR/szoftlab4.tex" | pdflatex_colorize
     if [ $? -ne 0 ]; then
-        echo "Generating of the documentation ended. [FAILED]"
+        debug_error "Generating of the documentation ended. [FAILED]"
         exit -1
     fi
+    
+    echo
+    echo
 }
 
 echo "Generating of the documentation started."
@@ -24,14 +29,14 @@ cd "$DOCS_DIR"
 # This script will generate the necessary LaTeX sources from the comments in the source code
 javadoc/javadoc_to_latex.sh
 if [ $? -ne 0 ]; then
-  echo 'Generation of LaTeX JavaDoc failed. [FAILED]'
+  debug_error 'Generation of LaTeX JavaDoc failed. [FAILED]'
   exit -1
 fi
 
 # We have to convert all our exported SVG files into PDFs, because LaTeX's SVG support is dreadful.
 ./svg_preprocess.sh
 if [ $? -ne 0 ]; then
-    echo "SVG to PDF conversion failed. [FAILED]"
+    debug_error "SVG to PDF conversion failed. [FAILED]"
     exit -1
 fi
 
@@ -49,4 +54,4 @@ rm -f *.{aux,lof,log,out,toc}
 
 cd "$TOP_DIR"
 
-echo "Generating of the documentation ended. [SUCCESS]"
+debug_success "Generating of the documentation ended. [SUCCESS]"

--- a/build_docs.sh
+++ b/build_docs.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Set the pipe's return value to the last non-zero value in the pipe (or 0 if everything succeeded)
+set -o pipefail
+
 # Enviromental variables so we can reuse them in our other scripts
 export TOP_DIR="$PWD"
 export SRC_DIR="$TOP_DIR/src"
@@ -12,7 +15,7 @@ source $LIB_DIR/debug_print.sh
 # one of the LaTeX outputs. Also note that this function doesn't clean up the temporaries,
 # which can be useful in the debugging process
 function generate_docs {
-    pdflatex -halt-on-error "$DOCS_DIR/szoftlab4.tex" | pdflatex_normalize
+    pdflatex -halt-on-error "$DOCS_DIR/szoftlab4.tex" | pdflatex_normalize | pdflatex_colorize
     if [ $? -ne 0 ]; then
         debug_error "Generating of the documentation ended. [FAILED]"
         exit -1

--- a/docs/svg_preprocess.sh
+++ b/docs/svg_preprocess.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+source $LIB_DIR/debug_print.sh
+
 # We default to rsvg-convert, since this is by far the most lightweight alterative for the conversion
 command -v "rsvg-convert" &> /dev/null
 if [ $? -eq 0 ]; then
@@ -27,7 +29,8 @@ fi
 # Since this will result in a loss of quality, it's reasonable to ask for confirmation. 
 command -v "convert" &> /dev/null
 if [ $? -eq 0 ]; then
-    read -p "Only rasterizing SVG to PDF converter found. This will reduce the image quality. Continue? [Y/n] " -n 1 -r
+    debug_warn "Only rasterizing SVG to PDF converter found. This will reduce the image quality."
+    read -p "Continue? [Y/n] " -n 1 -r
     echo # New line
     if [[ $REPLY =~ ^[Yy]$ ]]; then
         for file in $(find "$DOCS_DIR" -name '*.svg');
@@ -39,7 +42,5 @@ if [ $? -eq 0 ]; then
     fi
 fi
 
-# Signal the error if we couldn't convert the SVG files
-echo "No suitable SVG to PDF converter found."
 exit -1
 

--- a/lib/debug_print.sh
+++ b/lib/debug_print.sh
@@ -7,18 +7,21 @@ ncolors=$(tput colors)
 # grep.1: removes lines under the Underfull|Overfull diagnosic (the regex gets stuck on unknown characters for some reason) 
 # -------
 # awk.1:  removes Underfull/Overfull diagnostics, these will be ignored anyway
-# awk.2:  removes lines that contain fields with the format: ... [optional number] ...
+# awk.2:  removes lines that contain only numbers of nothing inside square brackets (with any amount of leading/trailing spaces or brackets)
 # awk.3:  removes lines that contain a "comment" (line contains: '<', '(', '{') that is probably not useful. 
 #         Useful comments are usually immediately followed up by an alphanumeric character. (This could produce false positives)
-# awk.4:  Removes lines that only have a single bracket in them
+# awk.4:  This is somewhat project specific and an ugly trick, but this gets rid of an \includegrapic diagnostic
+# awk.5:  Removes lines that only have a single bracket in them
+# -------
+# uniq: collapses multiple empty lines into one
 function pdflatex_normalize() {
     cat | 
     grep -v "^.*\\T1/.*" | 
     awk '{ gsub("^(Underfull|Overfull).*$", "");
-           gsub("^.*[[][0-9]*[]]*.*$", "");
+           gsub("^( *[<>{}()\\[\\]]* *[[][0-9]*[]]* *)*", "");
            gsub(".*[<({][/.>].*$", "");
-           gsub("^[)]{2,}.*$", "");
-           gsub("^[ ]*[<>{}()\\[\\]][ ]*$", "");
+           gsub("^<use.*$", "");
+           gsub("^ *[<>{}()\\[\\]] *$", "");
            print}' |  
     uniq
 }

--- a/lib/debug_print.sh
+++ b/lib/debug_print.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+ncolors=$(tput colors)
+
+function pdflatex_colorize() {
+    if test -n "$ncolors" && test $ncolors -ge 8; then
+        cat | awk '{ gsub("^.*[Ww]arning:", "\033[1;33m&\033[0m");
+
+                     gsub("^.*[Ee]rror.*",  "\033[1;31m&\033[0m");
+                     gsub("^!.*$",          "\033[1;31m&\033[0m"); 
+                     gsub("^l.[0-9]{1,}.*$",   "\033[1m&\033[0m");
+
+                     gsub("[Oo]utput written.*[.]pdf.*", "\033[1;32m&\033[0m"); 
+
+                     gsub("^This is pdfTeX.*$", "\033[1m&\033[0m"); print}'
+    else 
+        cat
+    fi
+}
+
+function debug_success() {
+    if test -n "$ncolors" && test $ncolors -ge 8; then
+        echo -e "\e[1;32m$1\e[0m"
+    else
+        echo $1
+    fi
+}
+
+function debug_warn() {
+    if test -n "$ncolors" && test $ncolors -ge 8; then
+        echo -e "\e[1;33m$1\e[0m"
+    else
+        echo $1
+    fi
+}
+
+function debug_error() {
+    if test -n "$ncolors" && test $ncolors -ge 8; then
+        echo -e "\e[1;31m$1\e[0m"
+    else
+        echo $1
+    fi
+}

--- a/lib/debug_print.sh
+++ b/lib/debug_print.sh
@@ -13,9 +13,9 @@ ncolors=$(tput colors)
 # awk.4:  Removes lines that only have a single bracket in them
 function pdflatex_normalize() {
     cat | 
-    grep -v "^.*\\T1/" | 
+    grep -v "^.*\\T1/.*" | 
     awk '{ gsub("^(Underfull|Overfull).*$", "");
-           gsub("^.*[[][0-9]{0,}[]]{0,}.*$", "");
+           gsub("^.*[[][0-9]*[]]*.*$", "");
            gsub(".*[<({][/.>].*$", "");
            gsub("^[)]{2,}.*$", "");
            gsub("^[ ]*[<>{}()\\[\\]][ ]*$", "");

--- a/lib/debug_print.sh
+++ b/lib/debug_print.sh
@@ -1,38 +1,56 @@
 #!/bin/bash
 
+# The number of colors the current shell supports
 ncolors=$(tput colors)
 
+# Greps and regexes line-by-line:
+# grep.1: removes lines under the Underfull|Overfull diagnosic (the regex gets stuck on unknown characters for some reason) 
+# -------
+# awk.1:  removes Underfull/Overfull diagnostics, these will be ignored anyway
+# awk.2:  removes lines that contain fields with the format: ... [optional number] ...
+# awk.3:  removes lines that contain a "comment" (line contains: '<', '(', '{') that is probably not useful. 
+#         Useful comments are usually immediately followed up by an alphanumeric character. (This could produce false positives)
+# awk.4:  Removes lines that only have a single bracket in them
 function pdflatex_normalize() {
+    cat | 
+    grep -v "^.*\\T1/" | 
+    awk '{ gsub("^(Underfull|Overfull).*$", "");
+           gsub("^.*[[][0-9]{0,}[]]{0,}.*$", "");
+           gsub(".*[<({][/.>].*$", "");
+           gsub("^[)]{2,}.*$", "");
+           gsub("^[ ]*[<>{}()\\[\\]][ ]*$", "");
+           print}' |  
+    uniq
+}
+
+# We can only use this function if we are on a terminal that supports colors, hence the if-else check
+# awk.1:  Colors lines containing "Warning:" to yellow (up till the colon)
+# awk.2:  Colors lines containing "Error" to red
+# awk.3:  LaTeX usually signals errors with !, so we color these lines red as well
+# awk.4:  Make the line number indicating the error bold
+# awk.5:  Color the successully written output line to green
+# awk.6:  Make the introductory text bold, so it's easier to distinguish between consequent runs
+function pdflatex_colorize() {
     if test -n "$ncolors" && test $ncolors -ge 8; then
-        cat | 
-        grep -v "^.*\\T1/" | 
-        grep -v ".*\[\] \[\].*" | 
-        awk '{ gsub("^(Underfull|Overfull).*$", "");
-               gsub("^[[].*[]].*$", "");
-               gsub("^[[].*$", "");
-               gsub("^.*[(][/.].*$", "");
-               gsub("[)][)].*$", "");
+        cat |
+        awk '{gsub("^.*[Ww]arning:", "\033[1;33m&\033[0m");
 
-               gsub(".*[<{][./>].*$", "");    
+              gsub("^.*[Ee]rror.*",  "\033[1;31m&\033[0m");
+              gsub("^!.*$",          "\033[1;31m&\033[0m"); 
+              gsub("^l.[0-9]{1,}.*$",   "\033[1m&\033[0m");
 
-               gsub("<use.*", "");
-               gsub("^[ ]*[>})]$", "");
+              gsub("[Oo]utput written.*[.]pdf.*", "\033[1;32m&\033[0m"); 
 
-               gsub("^.*[Ww]arning:", "\033[1;33m&\033[0m");
+              gsub("^This is pdfTeX.*$", "\033[1m&\033[0m"); 
+             
+              print}'
 
-               gsub("^.*[Ee]rror.*",  "\033[1;31m&\033[0m");
-               gsub("^!.*$",          "\033[1;31m&\033[0m"); 
-               gsub("^l.[0-9]{1,}.*$",   "\033[1m&\033[0m");
-
-               gsub("[Oo]utput written.*[.]pdf.*", "\033[1;32m&\033[0m"); 
-
-               gsub("^This is pdfTeX.*$", "\033[1m&\033[0m"); print}' | 
-        uniq
     else 
         cat
     fi
 }
 
+# Prints green text
 function debug_success() {
     if test -n "$ncolors" && test $ncolors -ge 8; then
         echo -e "\e[1;32m$1\e[0m"
@@ -41,6 +59,7 @@ function debug_success() {
     fi
 }
 
+# Prints yellow text
 function debug_warn() {
     if test -n "$ncolors" && test $ncolors -ge 8; then
         echo -e "\e[1;33m$1\e[0m"
@@ -49,6 +68,7 @@ function debug_warn() {
     fi
 }
 
+# Prints red text
 function debug_error() {
     if test -n "$ncolors" && test $ncolors -ge 8; then
         echo -e "\e[1;31m$1\e[0m"

--- a/lib/debug_print.sh
+++ b/lib/debug_print.sh
@@ -2,17 +2,32 @@
 
 ncolors=$(tput colors)
 
-function pdflatex_colorize() {
+function pdflatex_normalize() {
     if test -n "$ncolors" && test $ncolors -ge 8; then
-        cat | awk '{ gsub("^.*[Ww]arning:", "\033[1;33m&\033[0m");
+        cat | 
+        grep -v "^.*\\T1/" | 
+        grep -v ".*\[\] \[\].*" | 
+        awk '{ gsub("^(Underfull|Overfull).*$", "");
+               gsub("^[[].*[]].*$", "");
+               gsub("^[[].*$", "");
+               gsub("^.*[(][/.].*$", "");
+               gsub("[)][)].*$", "");
 
-                     gsub("^.*[Ee]rror.*",  "\033[1;31m&\033[0m");
-                     gsub("^!.*$",          "\033[1;31m&\033[0m"); 
-                     gsub("^l.[0-9]{1,}.*$",   "\033[1m&\033[0m");
+               gsub(".*[<{][./>].*$", "");    
 
-                     gsub("[Oo]utput written.*[.]pdf.*", "\033[1;32m&\033[0m"); 
+               gsub("<use.*", "");
+               gsub("^[ ]*[>})]$", "");
 
-                     gsub("^This is pdfTeX.*$", "\033[1m&\033[0m"); print}'
+               gsub("^.*[Ww]arning:", "\033[1;33m&\033[0m");
+
+               gsub("^.*[Ee]rror.*",  "\033[1;31m&\033[0m");
+               gsub("^!.*$",          "\033[1;31m&\033[0m"); 
+               gsub("^l.[0-9]{1,}.*$",   "\033[1m&\033[0m");
+
+               gsub("[Oo]utput written.*[.]pdf.*", "\033[1;32m&\033[0m"); 
+
+               gsub("^This is pdfTeX.*$", "\033[1m&\033[0m"); print}' | 
+        uniq
     else 
         cat
     fi

--- a/lib/debug_print.sh
+++ b/lib/debug_print.sh
@@ -16,9 +16,9 @@ ncolors=$(tput colors)
 # uniq: collapses multiple empty lines into one
 function pdflatex_normalize() {
     cat | 
-    grep -v "^.*\\T1/.*" | 
+    grep -v "^.*\\T1\/.*" | 
     awk '{ gsub("^(Underfull|Overfull).*$", "");
-           gsub("^( *[<>{}()\\[\\]]* *[[][0-9]*[]]* *)*", "");
+           gsub("^( *[<>{}()\\[\\]]* *[[][0-9]*[\\]]* *)*", "");
            gsub(".*[<({][/.>].*$", "");
            gsub("^<use.*$", "");
            gsub("^ *[<>{}()\\[\\]] *$", "");


### PR DESCRIPTION
A little quality of life improvement for the documentation build scripts. It produces more readable output from pdflatex (basicly leaves warnings, errors, successes, and removes the rest). It also colors relevant messages if the terminal supports it. This requires bash 3+ (2004 release so that shouldn't be a problem).

This should have **approval from all team members**, because even though this should be compatibile with every newer distro  and OS X, I have doubts about Git for Windows or MSYS supplying the correct applications. 

If it fails for anyone, feel free to close the PR, I can't fix it for other OSs easily. Even if it doesn't get merged feel free to use it, is IS a big improvement.

Output comparison: [gist](https://gist.github.com/Gustorn/4926e9675b8fa7bc3b9b)