### PR TITLE
Improved utlity scripts.

### DIFF
--- a/docs/svg_preprocess.sh
+++ b/docs/svg_preprocess.sh
@@ -8,7 +8,9 @@ if [ $? -eq 0 ]; then
     echo 'SVG prerocess opted for RSVG-Convert';
     for file in $(find "$DOCS_DIR" -name '*.svg');
     do
-        rsvg-convert -f pdf -o "${file%.*}.pdf" "$file"
+        if [ ! -f "${file%.*}.pdf" ]; then
+            rsvg-convert -f pdf -o "${file%.*}.pdf" "$file"
+        fi
     done
     
     exit $?
@@ -21,7 +23,9 @@ if [ $? -eq 0 ]; then
     echo 'SVG prerocess opted for Inkscape-convert';
     for file in $(find "$DOCS_DIR" -name '*.svg');
     do
-        inkscape --export-pdf="${file%.*}.pdf" --export-ignore-filters --export-area-drawing "$file"
+        if [ ! -f "${file%.*}.pdf" ]; then
+            inkscape --export-pdf="${file%.*}.pdf" --export-ignore-filters --export-area-drawing "$file"
+        fi
     done
     
     exit $?
@@ -38,7 +42,9 @@ if [ $? -eq 0 ]; then
     if [[ $REPLY =~ ^[Yy]$ ]]; then
         for file in $(find "$DOCS_DIR" -name '*.svg');
         do
-            convert "$file" "${file%.*}.pdf" 
+            if [ ! -f "${file%.*}.pdf" ]; then
+                convert "$file" "${file%.*}.pdf" 
+            fi
         done
         
         exit $?

--- a/lib/list_files.sh
+++ b/lib/list_files.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+cd ..
+
+name=
+path=
+size=
+split_info() {
+    local IFS=';'
+    set -f
+    split_line=( $@ )
+    set +f
+    name="${split_line[0]}"
+    path="${split_line[1]}"
+    size="${split_line[2]}"
+}
+
+array=
+split_lines() {
+    local IFS=$'\n'
+    set -f
+    array=( $@ )
+    set +f
+}
+
+files=$(find -type f -name *.java -printf '%f;%p;%s\n' | sed s/\\.\\///g | sort -t';' -k2)
+
+split_lines "$files"
+
+longest_path=-1
+for line in "${array[@]}"
+do
+    split_info "$line"
+    
+    if [ "${#path}" -gt "$longest_path" ]; then
+        longest_path="${#path}"
+    fi
+done
+
+for line in "${array[@]}"
+do
+    split_info "$line"
+    date=$(git log --diff-filter=A --follow --format=%ai -1 -- "$path" | awk '{gsub(" \\+[0-9]+.*$", ""); print}')
+     
+    printf "%-*s\t%s\t%5d bytes\n" "$longest_path" "$path" "$date" "$size" 
+done

--- a/lib/list_files_latex.sh
+++ b/lib/list_files_latex.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+cd ..
+
+name=
+path=
+size=
+split_info() {
+    local IFS=';'
+    set -f
+    split_line=( $@ )
+    set +f
+    name="${split_line[0]}"
+    path="${split_line[1]}"
+    size="${split_line[2]}"
+}
+
+array=
+split_lines() {
+    local IFS=$'\n'
+    set -f
+    array=( $@ )
+    set +f
+}
+
+files=$(find -type f -name *.java -printf '%f;%p;%s\n' | sed s/\\.\\///g | sort -t';' -k2)
+
+split_lines "$files"
+
+longest_path=-1
+for line in "${array[@]}"
+do
+    split_info "$line"
+    
+    if [ "${#path}" -gt "$longest_path" ]; then
+        longest_path="${#path}"
+    fi
+done
+
+echo "\\begin{tabularx}{\linewidth}{| l | l | l | X |}"
+echo "\\hline"
+echo "\\textbf{Fájl neve} & \\textbf{Méret} & \\textbf{Keletkezés ideje} & \\textbf{Tartalom} \\tabularnewline"
+echo "\\hline \\hline"
+echo "\\endhead"
+
+for line in "${array[@]}"
+do
+    split_info "$line"
+    date=$(git log --diff-filter=A --follow --format=%ai -1 -- "$path" | awk '{gsub(" \\+[0-9]+.*$", ""); gsub(" ", "~"); gsub(":[0-9]+$", "~"); gsub("-", "."); print}')
+
+    echo "\\fajl"
+    printf "{%s}\n{%d byte}\n{%s}\n{...}\n\n" "$path" "$size" "$date"
+done
+
+echo "\\end{tabularx}"


### PR DESCRIPTION
Added file listing scripts that can be used to generate the file listing needed in the documentation. It creates an alphabetically ordered list of Java source files (ordered by their full path), with size and creation date (according to git). Also, svg_preprocess.sh only generates the pdfs if they are not already generated (doc build times were getting pretty ridiculous).