### PR TITLE
Removed Gradle as a binary

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=gradle-2.2.1-bin.zip
+distributionUrl=https://services.gradle.org/distributions/gradle-2.2.1-bin.zip


### PR DESCRIPTION
It was a good idea, but we cannot submit zips that are ~30Mb large, so it makes sense to use a soluton that works when there's a working internet connection.